### PR TITLE
simAssimp.exportMeshes ignored parameters

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -835,9 +835,9 @@ void assimpExportMeshes(const std::vector<std::vector<float>>& vertices,const st
         {
             const float* v=&(vertices[shapeCompI])[0];
             if (upVector!=2)
-                pMesh->mVertices[i]=aiVector3D(v[3*i+0]*scaling,v[3*i+2]*scaling,-v[3*i+1]*scaling);
-            else
                 pMesh->mVertices[i]=aiVector3D(v[3*i+0]*scaling,v[3*i+1]*scaling,v[3*i+2]*scaling);
+            else
+                pMesh->mVertices[i]=aiVector3D(v[3*i+0]*scaling,v[3*i+2]*scaling,-v[3*i+1]*scaling);
         }
 
         pMesh->mNormals=nullptr;

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -835,9 +835,9 @@ void assimpExportMeshes(const std::vector<std::vector<float>>& vertices,const st
         {
             const float* v=&(vertices[shapeCompI])[0];
             if (upVector!=2)
-                pMesh->mVertices[i]=aiVector3D(v[3*i+0]*scaling,v[3*i+1]*scaling,v[3*i+2]*scaling);
+                pMesh->mVertices[i]=aiVector3D(v[3*i+0]*scaling,v[3*i+2]*scaling,-v[3*i+1]*scaling);
             else
-                pMesh->mVertices[i]=aiVector3D(v[3*i+1]*scaling,v[3*i+2]*scaling,v[3*i+0]*scaling);
+                pMesh->mVertices[i]=aiVector3D(v[3*i+0]*scaling,v[3*i+1]*scaling,v[3*i+2]*scaling);
         }
 
         pMesh->mNormals=nullptr;
@@ -908,6 +908,7 @@ void exportMeshes(SScriptCallBack *p, const char *cmd, exportMeshes_in *in, expo
                                     simSetLastError(LUA_EXPORTMESHES_COMMAND,"argument 5: invalid argument.");
                                     ok=false;
                                 }
+                                scaling = inArguments.getFloat(4);
                             }
                             if ( ok&&(inArguments.getSize()>5) )
                             {
@@ -916,6 +917,7 @@ void exportMeshes(SScriptCallBack *p, const char *cmd, exportMeshes_in *in, expo
                                     simSetLastError(LUA_EXPORTMESHES_COMMAND,"argument 6: invalid argument.");
                                     ok=false;
                                 }
+                                upVector = inArguments.getInt(5);
                             }
                             if ( ok&&(inArguments.getSize()>6) )
                             {
@@ -924,6 +926,7 @@ void exportMeshes(SScriptCallBack *p, const char *cmd, exportMeshes_in *in, expo
                                     simSetLastError(LUA_EXPORTMESHES_COMMAND,"argument 7: invalid argument.");
                                     ok=false;
                                 }
+                                options = inArguments.getInt(6);
                             }
                             if (ok)
                             {


### PR DESCRIPTION
related coppeliasim forum post: https://forum.coppeliarobotics.com/viewtopic.php?f=5&t=8857 

simAssimp.exportMeshes seemed to ignore the upvector and scaling parameters. this still seems to have been the case recently. this version (hopes to) corrects this. 

there still seems to be an issue with importing: the behavior of y and z upvector is reversed, at least compared to what i would expect.  